### PR TITLE
Add enterprise page and OpenRouter config

### DIFF
--- a/DIFF_20250705_235700.md
+++ b/DIFF_20250705_235700.md
@@ -1,0 +1,6 @@
+# DIFF 2025-07-05 23:57 UTC
+
+- Created `THOUGHTS.md` documenting development plan.
+- Added new enterprise page with chat and file upload at `web/src/pages/enterprise`.
+- Updated `web/src/routes.ts` to register `/enterprise` route.
+- Inserted sample models for OpenRouter in `conf/llm_factories.json`.

--- a/RECOMMENDATIONS_20250705_235700.md
+++ b/RECOMMENDATIONS_20250705_235700.md
@@ -1,0 +1,4 @@
+# Recommendations 2025-07-05 23:57 UTC
+
+- Consider adding more documentation for the existing web application to help new contributors navigate its large codebase.
+- Add automated environment setup for tests to avoid manual dependency installation errors.

--- a/THOUGHTS.md
+++ b/THOUGHTS.md
@@ -1,0 +1,13 @@
+# Development Process Thoughts
+
+## 2025-07-05 23:57 UTC
+- Initial exploration of repository. Confirmed existing React-based UI in `web/` which already uses TailwindCSS.
+- Determined no AGENTS.md instructions exist, so following default workflow.
+- Plan to add a new enterprise page that integrates a chat interface and document loader using existing components (`ChatContainer`, `FileUploader`).
+- Will update routing and configuration to expose this page at `/enterprise`.
+- Also will ensure OpenRouter models are included in `conf/llm_factories.json`.
+
+## 2025-07-06 00:05 UTC
+- Created new `EnterprisePage` combining existing chat container and file uploader.
+- Updated router to expose the new page.
+- Added sample OpenRouter models in `conf/llm_factories.json` for agent configuration.

--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1119,7 +1119,22 @@
             "logo": "",
             "tags": "LLM,IMAGE2TEXT",
             "status": "1",
-            "llm": []
+            "llm": [
+                {
+                    "llm_name": "openrouter/camel-2-7b",
+                    "tags": "LLM,CHAT,8k",
+                    "max_tokens": 8192,
+                    "model_type": "chat",
+                    "is_tools": true
+                },
+                {
+                    "llm_name": "openrouter/mistral-7b",
+                    "tags": "LLM,CHAT,32k",
+                    "max_tokens": 32768,
+                    "model_type": "chat",
+                    "is_tools": true
+                }
+            ]
         },
         {
             "name": "StepFun",

--- a/web/src/pages/enterprise/index.tsx
+++ b/web/src/pages/enterprise/index.tsx
@@ -1,0 +1,21 @@
+import ChatContainer from '@/pages/chat/chat-container';
+import FileUploader from '@/components/file-uploader';
+import { Flex } from 'antd';
+
+const EnterprisePage = () => {
+  return (
+    <Flex className="p-4 gap-4" vertical>
+      <h1 className="text-2xl font-bold">Enterprise RAG Interface</h1>
+      <div className="bg-card p-4 rounded-md shadow">
+        <h2 className="font-semibold mb-2">Upload Documents</h2>
+        <FileUploader multiple className="mb-4" />
+      </div>
+      <div className="bg-card p-4 rounded-md shadow flex-1">
+        <h2 className="font-semibold mb-2">Chat</h2>
+        <ChatContainer controller={new AbortController()} />
+      </div>
+    </Flex>
+  );
+};
+
+export default EnterprisePage;

--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -22,6 +22,7 @@ export enum Routes {
   Result = '/result',
   ResultView = `${Chunk}${Result}`,
   CloudCurio = '/cloudcurio',
+  Enterprise = '/enterprise',
 }
 
 const routes = [
@@ -162,6 +163,10 @@ const routes = [
       {
         path: Routes.CloudCurio,
         component: `@/pages${Routes.CloudCurio}`,
+      },
+      {
+        path: Routes.Enterprise,
+        component: `@/pages${Routes.Enterprise}`,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- create development log `THOUGHTS.md`
- document repository changes in `DIFF_20250705_235700.md`
- add recommendations in `RECOMMENDATIONS_20250705_235700.md`
- add `EnterprisePage` with chat interface and file uploader
- expose new page at `/enterprise`
- add sample OpenRouter models to configuration

## Testing
- `pip install requests`
- `pytest -q` *(fails: Environment variable ZHIPU_AI_API_KEY must be set)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb502750832aaf30dde3e40fc31f

## Summary by Sourcery

Add a new enterprise page with document upload and chat interface, expose it via the application router, and include sample OpenRouter model configurations, alongside development logs and recommendations.

New Features:
- Introduce EnterprisePage at /enterprise with a file uploader and chat interface
- Add sample OpenRouter models to llm_factories.json

Documentation:
- Add THOUGHTS.md to capture development process
- Add DIFF_20250705_235700.md for change documentation
- Add RECOMMENDATIONS_20250705_235700.md for repository improvement suggestions