### PR TITLE
Add govinfo ingestion pipeline script

### DIFF
--- a/DIFF_20250710_035306.md
+++ b/DIFF_20250710_035306.md
@@ -1,0 +1,7 @@
+# DIFF 2025-07-10 03:53 UTC
+
+- Adding scripts directory and govinfo ingestion pipeline.
+- Documented results of attempted ingestion from govinfo endpoints.
+- Added README notes on running new script.
+- Ran `pip install` to install requests, sentence-transformers and chromadb.
+- Ingestion script execution failed due to blocked model download from HuggingFace.

--- a/README.md
+++ b/README.md
@@ -403,3 +403,14 @@ See the [RAGFlow Roadmap 2025](https://github.com/infiniflow/ragflow/issues/4214
 
 RAGFlow flourishes via open-source collaboration. In this spirit, we embrace diverse contributions from the community.
 If you would like to be a part, review our [Contribution Guidelines](https://ragflow.io/docs/dev/contributing) first.
+
+## 🏛 GovInfo ingestion example
+
+Use `scripts/govinfo_ingest.py` to fetch sample documents from [GovInfo](https://www.govinfo.gov/). The script downloads data from the bulkdata and API endpoints, generates embeddings with `sentence-transformers`, and stores them in a local ChromaDB database.
+
+Run the script after installing its dependencies:
+
+```bash
+pip install sentence-transformers chromadb
+python scripts/govinfo_ingest.py
+```

--- a/RECOMMENDATIONS_20250710_035306.md
+++ b/RECOMMENDATIONS_20250710_035306.md
@@ -1,0 +1,4 @@
+# Recommendations 2025-07-10 03:53 UTC
+
+- Provide local configuration examples for using new ingestion pipeline.
+- Consider packaging script as CLI tool with parameter validation.

--- a/scripts/govinfo_ingest.py
+++ b/scripts/govinfo_ingest.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Simple data pipeline to ingest documents from govinfo endpoints."""
+import os
+import tempfile
+import requests
+import zipfile
+from pathlib import Path
+
+from sentence_transformers import SentenceTransformer
+import chromadb
+
+# Setup embedding model and vector DB
+EMBED_MODEL = os.environ.get("EMBED_MODEL", "all-MiniLM-L6-v2")
+client = chromadb.Client()
+collection = client.create_collection("govinfo")
+model = SentenceTransformer(EMBED_MODEL)
+
+
+def fetch_bulkdata(collection_id: str, congress: str, dest: Path) -> Path:
+    """Download a sample bulkdata file."""
+    url = f"https://www.govinfo.gov/bulkdata/{collection_id}/{congress}"
+    r = requests.get(url, timeout=30)
+    r.raise_for_status()
+    dest.mkdir(parents=True, exist_ok=True)
+    fp = dest / f"{collection_id}_{congress}.zip"
+    with open(fp, "wb") as f:
+        f.write(r.content)
+    # Extract if zip
+    with zipfile.ZipFile(fp, "r") as z:
+        z.extractall(dest)
+    return dest
+
+
+def fetch_api_package(package_id: str, api_key: str, dest: Path) -> Path:
+    url = f"https://api.govinfo.gov/packages/{package_id}?api_key={api_key}"
+    r = requests.get(url, timeout=30)
+    r.raise_for_status()
+    dest.mkdir(parents=True, exist_ok=True)
+    fp = dest / f"{package_id}.json"
+    with open(fp, "wb") as f:
+        f.write(r.content)
+    return fp
+
+
+def ingest_text(text: str, meta: dict):
+    embedding = model.encode(text)
+    collection.add(documents=[text], metadatas=[meta], ids=[meta.get("id")])
+
+
+def main():
+    api_key = os.environ.get("GOVINFO_API_KEY", "DEMO_KEY")
+    with tempfile.TemporaryDirectory() as td:
+        td_path = Path(td)
+        try:
+            bulk_path = fetch_bulkdata("BILLSTATUS", "118", td_path)
+            print(f"Downloaded bulk data to {bulk_path}")
+        except Exception as e:
+            print(f"Bulkdata fetch failed: {e}")
+        try:
+            pkg = fetch_api_package("BILLS-118hr1", api_key, td_path)
+            print(f"Downloaded api package to {pkg}")
+        except Exception as e:
+            print(f"API fetch failed: {e}")
+        for fp in td_path.rglob("*"):
+            if fp.suffix in {".xml", ".txt", ".json"}:
+                try:
+                    text = fp.read_text(encoding="utf-8", errors="ignore")
+                    ingest_text(text, {"id": fp.name})
+                except Exception as e:
+                    print(f"Failed ingest {fp}: {e}")
+        print(f"Indexed {collection.count()} documents")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document new govinfo ingestion example in README
- add `govinfo_ingest.py` for fetching bulkdata and API content
- record changes in timestamped DIFF and RECOMMENDATIONS files

## Testing
- `pip install requests sentence-transformers chromadb` *(success)*
- `python scripts/govinfo_ingest.py` *(failed: DNS errors downloading model)*

------
https://chatgpt.com/codex/tasks/task_e_686f381c6760832abb49f45b25b686ec

## Summary by Sourcery

Introduce a GovInfo ingestion pipeline for fetching, embedding, and indexing government documents, document its usage, and record ingestion run outputs and recommendations.

New Features:
- Add govinfo_ingest.py script to fetch bulkdata and API content from GovInfo, generate embeddings with sentence-transformers, and store documents in a ChromaDB collection

Documentation:
- Document the GovInfo ingestion example in README with installation and usage instructions

Chores:
- Add timestamped DIFF and RECOMMENDATIONS files capturing ingestion run results and improvement suggestions